### PR TITLE
Fix/sidekick library

### DIFF
--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -44,12 +44,17 @@
               },
               {
                 width: '768px',
-                label: 'Medium',
+                label: 'Small Tablet',
+                icon: 'device-tablet',
+              },
+              {
+                width: '992px',
+                label: 'Large Tablet',
                 icon: 'device-tablet',
               },
               {
                 width: '100%',
-                label: 'Large',
+                label: 'Desktop',
                 icon: 'device-desktop',
                 default: true,
               },


### PR DESCRIPTION
Added another viewport for the library html file so that we can view 

- mobile:600px
- small tablet: 768px
- large tablet: 998px 
- desktop 100% width

URL for testing:
- https://fix-sidekick-library--avendra--avendra-eds.aem.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/accordion&index=0
