### PR TITLE
Article Cards (List, Gallery, Resources)

### DIFF
--- a/blocks/article-cards/article-cards.css
+++ b/blocks/article-cards/article-cards.css
@@ -89,7 +89,7 @@
   margin: 0;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(25rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(23rem, 1fr));
   gap: 3.25rem 2.5rem;
 }
 
@@ -138,6 +138,15 @@
     margin: 0;
   }
   
+}
+
+.article-cards.list > ul > li {
+  padding: 2.5rem 0;
+  border-bottom: .0625rem solid gray;
+}
+
+.article-cards.list > ul > li:last-child {
+  border: none;
 }
 
 /* RESOURCES STYLES */

--- a/blocks/article-cards/article-cards.css
+++ b/blocks/article-cards/article-cards.css
@@ -1,20 +1,16 @@
 
-/* Default: Gallery of cards */
-.article-cards.gallery > ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(25rem, 1fr));
-  gap: 2.5rem; 
-}
+/* ALL STYLES */
 
-/* List of cards */
-.article-cards.list > ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: block; 
+@media (width < 600px) {
+  .article-cards > ul > li {
+    justify-self: center;
+    padding: 1.25rem 0;
+    border-bottom: 1px solid gray;
+  }
+
+  .article-cards > ul > li:last-child {
+    border: none;
+  }
 }
 
 .article-cards > ul > li {
@@ -22,29 +18,35 @@
   background-color: var(--background-color);
 }
 
-.article-cards.list > ul > li {
-  margin-bottom: 2.5rem;
-}
-
-
 .article-cards h6 {
   padding: 0;
   margin-top: 1.75rem;
   margin-bottom: .5rem;
 }
 
-
 .article-cards p {
-  padding: 0;
+  font-weight: 400;
+  font-size: var(--caption-text);
+  padding: .3125rem 0;
   margin: 0;
 }
 
-.article-cards p strong {
-  display: inline-block;
-  font-size: var(--caption-text);
-  font-weight: normal;
-  padding: 0;
-  margin-bottom: 1rem;
+.article-cards .article-card-subtitle strong {
+  font-weight: var(--text-regular);
+}
+
+@media (width >= 600px) {
+  .article-cards p {
+    font-size: var(--body-text);
+  }
+  
+  .article-cards p strong {
+    font-size: var(--body-text);
+  }
+
+  .article-cards .article-card-date {
+    font-size: var(--body-text);
+  }
 }
 
 .article-cards .article-cards-card-image {
@@ -54,27 +56,108 @@
   border-radius: .75rem;
 }
 
-
 .article-cards > ul > li img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.article-cards-card-body p.button-container:has(em) {
+.article-cards-card-body .article-cards-card-buttons p.button-container {
   display: inline-flex;
   align-items: center;
-  margin-right: .75rem;
+  margin-right: 0.75rem;
   font-size: var(--caption-text);
 }
 
- .article-cards-card-body > .button-container:first-of-type > a.button {
+ .article-cards-card-body > .article-card-title > a.button {
   all: unset;
   cursor: pointer;
+  font-weight: 500;
+  font-size: var(--body-text);
 }
 
-.article-cards-card-body > .button-container:first-of-type > a.button:hover {
+.article-cards-card-body > .article-card-title > a.button:hover {
   text-decoration: underline;
   color: var(--button-hover-sky);
   cursor: pointer;
+}
+
+/* GALLERY STYLES */
+
+.article-cards.gallery > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(25rem, 1fr));
+  gap: 3.25rem 2.5rem;
+}
+
+.article-cards.gallery > ul > li {
+  justify-self: center;
+}
+
+.article-cards.gallery .article-card-subtitle {
+  display: none;
+}
+
+@media (width < 600px) {
+  .article-cards.gallery > ul {
+    gap: 0;
+  }
+}
+
+/* LIST STYLES */
+.article-cards.list > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: block; 
+}
+
+/* LIST CARD DESKTOP */
+@media (width > 600px) {
+  .article-cards.list > ul > li {
+    display: flex;
+    gap: 2.5rem;
+    width: 100%;
+    padding: 2.5rem 0;
+    border-bottom: .0625rem solid gray;
+  }
+
+  .article-cards.list .article-cards-card-image {
+    width: 18.125rem;
+    height: 10.625rem;
+  }
+
+  .article-cards.list > ul > li:last-child {
+    border: none;
+  }
+
+  .article-cards.list h6 {
+    margin: 0;
+  }
+  
+}
+
+/* RESOURCES STYLES */
+
+.article-cards.resources > ul > li {
+  border-bottom: .0625rem solid gray;
+  padding: 2.5rem 0;
+}
+
+.article-cards.resources > ul > li:last-child {
+  border: none;
+}
+
+.article-cards.resources > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: block; 
+}
+
+.article-cards.resources .article-card-subtitle {
+  display: none;
 }

--- a/blocks/article-cards/article-cards.css
+++ b/blocks/article-cards/article-cards.css
@@ -1,0 +1,80 @@
+
+/* Default: Gallery of cards */
+.article-cards.gallery > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(25rem, 1fr));
+  gap: 2.5rem; 
+}
+
+/* List of cards */
+.article-cards.list > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: block; 
+}
+
+.article-cards > ul > li {
+  width: 25rem; 
+  background-color: var(--background-color);
+}
+
+.article-cards.list > ul > li {
+  margin-bottom: 2.5rem;
+}
+
+
+.article-cards h6 {
+  padding: 0;
+  margin-top: 1.75rem;
+  margin-bottom: .5rem;
+}
+
+
+.article-cards p {
+  padding: 0;
+  margin: 0;
+}
+
+.article-cards p strong {
+  display: inline-block;
+  font-size: var(--caption-text);
+  font-weight: normal;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.article-cards .article-cards-card-image {
+  width: 100%;      
+  height: 14.3125rem;    
+  overflow: hidden; 
+  border-radius: .75rem;
+}
+
+
+.article-cards > ul > li img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.article-cards-card-body p.button-container:has(em) {
+  display: inline-flex;
+  align-items: center;
+  margin-right: .75rem;
+  font-size: var(--caption-text);
+}
+
+ .article-cards-card-body > .button-container:first-of-type > a.button {
+  all: unset;
+  cursor: pointer;
+}
+
+.article-cards-card-body > .button-container:first-of-type > a.button:hover {
+  text-decoration: underline;
+  color: var(--button-hover-sky);
+  cursor: pointer;
+}

--- a/blocks/article-cards/article-cards.css
+++ b/blocks/article-cards/article-cards.css
@@ -145,16 +145,16 @@
   border-bottom: .0625rem solid gray;
 }
 
+.article-cards.resources > ul > li {
+  border-bottom: .0625rem solid gray;
+  padding: 2.5rem 0;
+}
+
 .article-cards.list > ul > li:last-child {
   border: none;
 }
 
 /* RESOURCES STYLES */
-
-.article-cards.resources > ul > li {
-  border-bottom: .0625rem solid gray;
-  padding: 2.5rem 0;
-}
 
 .article-cards.resources > ul > li:last-child {
   border: none;

--- a/blocks/article-cards/article-cards.js
+++ b/blocks/article-cards/article-cards.js
@@ -1,0 +1,18 @@
+import { createOptimizedPicture } from '../../scripts/aem.js';
+
+export default function decorate(block) {
+  /* change to ul, li */
+  const ul = document.createElement('ul');
+  [...block.children].forEach((row) => {
+    const li = document.createElement('li');
+    while (row.firstElementChild) li.append(row.firstElementChild);
+    [...li.children].forEach((div) => {
+      if (div.children.length === 1 && div.querySelector('picture')) div.className = 'article-cards-card-image';
+      else div.className = 'article-cards-card-body';
+    });
+    ul.append(li);
+  });
+  ul.querySelectorAll('picture > img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
+  block.textContent = '';
+  block.append(ul);
+}

--- a/blocks/article-cards/article-cards.js
+++ b/blocks/article-cards/article-cards.js
@@ -15,4 +15,31 @@ export default function decorate(block) {
   ul.querySelectorAll('picture > img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
   block.textContent = '';
   block.append(ul);
+
+  // CUSTOM code for decorating sections for Article Cards
+  ul.querySelectorAll('.article-cards-card-body').forEach((body) => {
+    const children = Array.from(body.children);
+    if (children.length < 3) return;
+    const titleP = children[1];
+    titleP.classList.add('article-card-title');
+    let dateIndex;
+    if (children[2].querySelector('strong')) {
+      children[2].classList.add('article-card-subtitle');
+      dateIndex = 3;
+    } else {
+      dateIndex = 2;
+    }
+    if (children[dateIndex]) {
+      children[dateIndex].classList.add('article-card-date');
+    }
+    if (children.length > dateIndex + 1) {
+      const buttonsContainer = document.createElement('div');
+      buttonsContainer.className = 'article-cards-card-buttons';
+      const extraButtons = children.slice(dateIndex + 1);
+      extraButtons.forEach((btn) => {
+        buttonsContainer.append(btn);
+      });
+      body.append(buttonsContainer);
+    }
+  });
 }


### PR DESCRIPTION
Test out here:
https://article-cards--avendra--avendra-eds.hlx.page/tools/sidekick/blocks/article-cards

<img width="704" alt="image" src="https://github.com/user-attachments/assets/78bd876e-2388-4809-9cab-8b20502ff710" />

The format for the cards are fixed:
1. H6 [always present]
2. Title (Linked p) [Always present]
3. Subtitle (bold p) [May or may not be present] [Automatically hidden from resources and gallery view]
4. Buttons [Italic (em) p] [0 or more present]



Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
