### PR TITLE
Fix alignment for number banner

### DIFF
--- a/blocks/banners/numbers-banner.css
+++ b/blocks/banners/numbers-banner.css
@@ -16,14 +16,12 @@
     display: flex;
     flex-direction: column;
     align-self: stretch;
-    margin: 0 auto;
 }
 
 .numbers-banner > div:last-child {
     display: flex;
     flex-direction: column;
     align-self: stretch;
-    margin: 0 auto;
     max-width: 18.5rem;
     width: 100%;
     align-items: flex-start;
@@ -71,7 +69,6 @@
         display: flex;
         flex-direction: column;
         align-self: stretch;
-        margin: 0 auto;
         max-width: 25.5rem;
         width: 100%;
         align-items: flex-start;
@@ -88,7 +85,6 @@
         display: flex;
         flex-direction: column;
         align-self: stretch;
-        margin: 0 auto;
         max-width: 35.5rem;
         width: 100%;
         align-items: flex-start;
@@ -118,7 +114,6 @@
     .numbers-banner > div:last-child {
         display: flex;
         flex-direction: row;
-        margin: 0 auto;
         max-width: 80rem;
         width: 100%;
         align-items: flex-start;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Simple fix for the numbers banner to have it left aligned for screen sizes
![Screenshot 2025-02-12 at 10 37 33 AM](https://github.com/user-attachments/assets/85b49f76-71ee-4d21-841c-a94f34d6fb5a)

Test URLs: https://fix-number-banner--avendra--avendra-eds.aem.live/banners/


