### PR TITLE
Fix: Article banner height and paddings

### DIFF
--- a/blocks/article-banner/article-banner.css
+++ b/blocks/article-banner/article-banner.css
@@ -165,6 +165,11 @@
   .article-banner > div > div:last-child {
     padding: 14.3rem 0 0 5rem;
   }
+
+  .article-banner.no-image {
+    height: 28.4375rem;
+  }
+  
 }
 
 @media (width >= 1440px) {
@@ -177,6 +182,6 @@
   }
   
   .article-banner > div > div:last-child {
-    padding: 10rem 0 0 5rem;
+    padding: 14rem 0 0 5rem;
   }
 }


### PR DESCRIPTION
Improved Article Banner padding for >= 1440px:
![image](https://github.com/user-attachments/assets/af28902c-3117-41d5-8733-90148e9c31bb)


Improved Article No Image Height for >= 1280px:

![image](https://github.com/user-attachments/assets/440be064-c00d-4816-85c3-9088bc510baa)


